### PR TITLE
🔀 :: [#5] - jwt 보안 강화

### DIFF
--- a/src/main/kotlin/com/practice/graphql/GraphqlApplication.kt
+++ b/src/main/kotlin/com/practice/graphql/GraphqlApplication.kt
@@ -1,9 +1,11 @@
 package com.practice.graphql
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 class GraphqlApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/practice/graphql/global/jwt/TokenProvider.kt
+++ b/src/main/kotlin/com/practice/graphql/global/jwt/TokenProvider.kt
@@ -14,10 +14,10 @@ import java.util.Date
 
 @Component
 class TokenProvider {
-    private val ACCESS_TOKEN_EXPIRE_TIME:Long = 1000 * 60 * 60 * 3// 3시간
-    private val REFRESH_TOKEN_EXPIRE_TIME:Long= ACCESS_TOKEN_EXPIRE_TIME/3 * 24 * 30 * 6
     @Value("\${jwt.secret}")
     private val SECRET_KEY:String = ""
+    private val accessExpireTime: Long = 1000 * 60 * 60 * 3
+    private val refreshExpireTime: Long= accessExpireTime/3 * 24 * 30 * 6
 
     private enum class TokenType(val value: String){
         ACCESS_TOKEN("accessToken"),
@@ -69,8 +69,10 @@ class TokenProvider {
 
     fun createAccessToken(email: String, roles: List<Role>): String{
         val claims = Jwts.claims()
-        claims.put(TokenClaimName.ROLES.value, roles)
-        return createToken(TokenType.ACCESS_TOKEN, email, ACCESS_TOKEN_EXPIRE_TIME, claims)
+        claims[TokenClaimName.ROLES.value] = roles
+        return createToken(TokenType.ACCESS_TOKEN, email, accessExpireTime, accessSecret, claims)
     }
-    fun createRefreshToken(email: String): String = createToken(TokenType.REFRESH_TOKEN, email, REFRESH_TOKEN_EXPIRE_TIME, Jwts.claims())
+    fun createRefreshToken(email: String): String {
+        return createToken(TokenType.REFRESH_TOKEN, email, refreshExpireTime, refreshSecret, Jwts.claims())
+    }
 }

--- a/src/main/kotlin/com/practice/graphql/global/jwt/TokenProvider.kt
+++ b/src/main/kotlin/com/practice/graphql/global/jwt/TokenProvider.kt
@@ -14,10 +14,12 @@ import java.util.Date
 
 @Component
 class TokenProvider {
-    @Value("\${jwt.secret}")
-    private val SECRET_KEY:String = ""
     private val accessExpireTime: Long = 1000 * 60 * 60 * 3
     private val refreshExpireTime: Long= accessExpireTime/3 * 24 * 30 * 6
+    @Value("\${jwt.access-secret}")
+    private val accessSecret: String = ""
+    @Value("\${jwt.refresh-secret}")
+    private val refreshSecret :String = ""
 
     private enum class TokenType(val value: String){
         ACCESS_TOKEN("accessToken"),
@@ -56,14 +58,14 @@ class TokenProvider {
         }
     }
 
-    private fun createToken(type: TokenType, email: String, expiredTime: Long, claims: Claims): String{
-        claims.put(TokenClaimName.USER_EMAIL.value, email)
-        claims.put(TokenClaimName.TOKEN_TYPE.value, type.value)
+    private fun createToken(type: TokenType, email: String, expiredTime: Long, secretKey: String, claims: Claims): String{
+        claims[TokenClaimName.USER_EMAIL.value] = email
+        claims[TokenClaimName.TOKEN_TYPE.value] = type.value
         return Jwts.builder()
             .addClaims(claims)
             .setIssuedAt(Date(System.currentTimeMillis()))
             .setExpiration(Date(System.currentTimeMillis() + expiredTime))
-            .signWith(getSignInKey(SECRET_KEY), SignatureAlgorithm.HS256)
+            .signWith(getSignInKey(secretKey), SignatureAlgorithm.HS256)
             .compact()
     }
 

--- a/src/main/kotlin/com/practice/graphql/global/jwt/TokenProvider.kt
+++ b/src/main/kotlin/com/practice/graphql/global/jwt/TokenProvider.kt
@@ -1,6 +1,7 @@
 package com.practice.graphql.global.jwt
 
 import com.practice.graphql.domain.member.Role
+import com.practice.graphql.global.jwt.property.JwtProperty
 import io.jsonwebtoken.Claims
 import io.jsonwebtoken.ExpiredJwtException
 import io.jsonwebtoken.Jwts
@@ -13,14 +14,9 @@ import java.security.Key
 import java.util.Date
 
 @Component
-class TokenProvider {
-    private val accessExpireTime: Long = 1000 * 60 * 60 * 3
-    private val refreshExpireTime: Long= accessExpireTime/3 * 24 * 30 * 6
-    @Value("\${jwt.access-secret}")
-    private val accessSecret: String = ""
-    @Value("\${jwt.refresh-secret}")
-    private val refreshSecret :String = ""
-
+class TokenProvider(
+    private val jwtProperty: JwtProperty
+) {
     private enum class TokenType(val value: String){
         ACCESS_TOKEN("accessToken"),
         REFRESH_TOKEN("refreshToken")
@@ -31,15 +27,10 @@ class TokenProvider {
         ROLES("roles")
     }
 
-    private fun getSignInKey(secretKey: String): Key{
-        val bytes = secretKey.toByteArray(StandardCharsets.UTF_8)
-        return Keys.hmacShaKeyFor(bytes)
-    }
-
     private fun extractAccessClaims(token: String): Claims{
         val tokenR = token.replace("Bearer ", "")
         return Jwts.parserBuilder()
-            .setSigningKey(getSignInKey(accessSecret))
+            .setSigningKey(jwtProperty.accessSecret)
             .build()
             .parseClaimsJws(tokenR)
             .body
@@ -48,7 +39,7 @@ class TokenProvider {
     private fun extractRefreshToken(token: String): Claims{
         val tokenR = token.replace("Bearer ", "")
         return Jwts.parserBuilder()
-            .setSigningKey(getSignInKey(refreshSecret))
+            .setSigningKey(jwtProperty.refreshSecret)
             .build()
             .parseClaimsJws(tokenR)
             .body
@@ -58,23 +49,23 @@ class TokenProvider {
 
     fun getTokenType(token: String): String = extractAccessClaims(token).get(TokenClaimName.TOKEN_TYPE.value, String::class.java)
 
-    private fun createToken(type: TokenType, email: String, expiredTime: Long, secretKey: String, claims: Claims): String{
+    private fun createToken(type: TokenType, email: String, expiredTime: Long, secretKey: Key, claims: Claims): String{
         claims[TokenClaimName.USER_EMAIL.value] = email
         claims[TokenClaimName.TOKEN_TYPE.value] = type.value
         return Jwts.builder()
             .addClaims(claims)
             .setIssuedAt(Date(System.currentTimeMillis()))
             .setExpiration(Date(System.currentTimeMillis() + expiredTime))
-            .signWith(getSignInKey(secretKey), SignatureAlgorithm.HS256)
+            .signWith(secretKey, SignatureAlgorithm.HS256)
             .compact()
     }
 
     fun createAccessToken(email: String, roles: List<Role>): String{
         val claims = Jwts.claims()
         claims[TokenClaimName.ROLES.value] = roles
-        return createToken(TokenType.ACCESS_TOKEN, email, accessExpireTime, accessSecret, claims)
+        return createToken(TokenType.ACCESS_TOKEN, email, jwtProperty.accessExpireTime, jwtProperty.accessSecret, claims)
     }
     fun createRefreshToken(email: String): String {
-        return createToken(TokenType.REFRESH_TOKEN, email, refreshExpireTime, refreshSecret, Jwts.claims())
+        return createToken(TokenType.REFRESH_TOKEN, email, jwtProperty.refreshExpireTime, jwtProperty.refreshSecret, Jwts.claims())
     }
 }

--- a/src/main/kotlin/com/practice/graphql/global/jwt/TokenProvider.kt
+++ b/src/main/kotlin/com/practice/graphql/global/jwt/TokenProvider.kt
@@ -36,27 +36,27 @@ class TokenProvider {
         return Keys.hmacShaKeyFor(bytes)
     }
 
-    private fun extractAllClaims(token: String): Claims{
+    private fun extractAccessClaims(token: String): Claims{
         val tokenR = token.replace("Bearer ", "")
         return Jwts.parserBuilder()
-            .setSigningKey(getSignInKey(SECRET_KEY))
+            .setSigningKey(getSignInKey(accessSecret))
             .build()
             .parseClaimsJws(tokenR)
             .body
     }
 
-    fun getUserEmail(token: String): String = extractAllClaims(token).get(TokenClaimName.USER_EMAIL.value, String::class.java)
-
-    fun getTokenType(token: String): String = extractAllClaims(token).get(TokenClaimName.TOKEN_TYPE.value, String::class.java)
-
-    fun isTokenExpired(token: String): Boolean{
-        try{
-            extractAllClaims(token).expiration
-            return false
-        }catch (e: ExpiredJwtException){
-            return true
-        }
+    private fun extractRefreshToken(token: String): Claims{
+        val tokenR = token.replace("Bearer ", "")
+        return Jwts.parserBuilder()
+            .setSigningKey(getSignInKey(refreshSecret))
+            .build()
+            .parseClaimsJws(tokenR)
+            .body
     }
+
+    fun getUserEmail(token: String): String = extractAccessClaims(token).get(TokenClaimName.USER_EMAIL.value, String::class.java)
+
+    fun getTokenType(token: String): String = extractAccessClaims(token).get(TokenClaimName.TOKEN_TYPE.value, String::class.java)
 
     private fun createToken(type: TokenType, email: String, expiredTime: Long, secretKey: String, claims: Claims): String{
         claims[TokenClaimName.USER_EMAIL.value] = email

--- a/src/main/kotlin/com/practice/graphql/global/jwt/property/JwtProperty.kt
+++ b/src/main/kotlin/com/practice/graphql/global/jwt/property/JwtProperty.kt
@@ -1,0 +1,16 @@
+package com.practice.graphql.global.jwt.property
+
+import io.jsonwebtoken.security.Keys
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.nio.charset.StandardCharsets
+
+@ConfigurationProperties(prefix = "jwt")
+class JwtProperty(
+    accessSecret: String,
+    refreshSecret: String,
+    val accessExpireTime: Long,
+    val refreshExpireTime: Long,
+) {
+    val accessSecret = Keys.hmacShaKeyFor(accessSecret.toByteArray(StandardCharsets.UTF_8))
+    val refreshSecret = Keys.hmacShaKeyFor(refreshSecret.toByteArray(StandardCharsets.UTF_8))
+}


### PR DESCRIPTION
## 개요
* 기존 토큰을 accessToken과 refreshToken으로 분리
* 각 토큰의 유효 시간을 설정
## 작업내용
* 토큰 만료기간 저장 변수 네이밍 수정
* 각 토큰 타입에 따른 시크릿값 추가
* 각 토큰 시크릿값 분리에 따른 메서드 수정
* jwt 파싱 필터 리펙토링
* 시크릿 값과 유효기간을 property로 분리